### PR TITLE
enable ffmpeg-full extension

### DIFF
--- a/io.gitlab.adhami3310.Footage.json
+++ b/io.gitlab.adhami3310.Footage.json
@@ -6,6 +6,13 @@
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],
+    "add-extensions" : {
+        "org.freedesktop.Platform.ffmpeg-full" : {
+            "directory" : "lib/ffmpeg",
+            "version" : "22.08",
+            "add-ld-path" : "."
+        }
+    },
     "cleanup-commands": [
         "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
     ],


### PR DESCRIPTION
Adding this extension which is built by the SDK (so; the ffmpeg ABI matches the less capable one bundled with the runtime) will provide a fully-featured ffmpeg version to your app. It will be installed automatically, but users who uninstall it or choose not to use it will be able to continue as-is with the default bundled ffmpeg.